### PR TITLE
[QE-4025] Tweak MacOS version finder to work with two version identifiers as well as three

### DIFF
--- a/Helpers/Appium_Helper.js
+++ b/Helpers/Appium_Helper.js
@@ -130,7 +130,7 @@ class Appium_Helper {
 		if (platform === 'darwin') {
 			version = exec('sw_vers');
 			version = version.toString('utf8');
-			version = version.match(/\d+\.\d+\.\d+/)[0];
+			version = version.match(/\d+\.\d+\.*\d*/)[0];
 		} else if (platform === 'windows') {
 			// TODO: Add in a method of finding Windows platform version
 			version = '10'; // Just a guess for now

--- a/Helpers/Appium_Helper.js
+++ b/Helpers/Appium_Helper.js
@@ -130,7 +130,7 @@ class Appium_Helper {
 		if (platform === 'darwin') {
 			version = exec('sw_vers');
 			version = version.toString('utf8');
-			version = version.match(/\d+\.\d+\.*\d*/)[0];
+			version = version.match(/\d+\.\d+\.?\d{0,2}/)[0];
 		} else if (platform === 'windows') {
 			// TODO: Add in a method of finding Windows platform version
 			version = '10'; // Just a guess for now


### PR DESCRIPTION
Alter regular expression to only expect two sections of version number, but can identify three